### PR TITLE
fix adding extra spaces within the section of PreBuild event

### DIFF
--- a/src/csproj.ts
+++ b/src/csproj.ts
@@ -74,8 +74,8 @@ export async function persist(csproj: Csproj, indent = 2) {
 
     // Add byte order mark.
     const xmlFinal = ('\ufeff' + xmlString)
-        .replace(/\n/g, '\r\n') // use CRLF
-        .replace(/\r?\n$/, '') // no newline at end of file
+        .replace(/(?<!\r)>\n/g, '\r\n') // use CRLF
+        .replace(/(\r)?(\n)+$/, '') // no newline at end of file
 
     await fs.writeFile(csproj.fsPath, xmlFinal)
 

--- a/test/fixtures/Sample.csproj
+++ b/test/fixtures/Sample.csproj
@@ -6,6 +6,13 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
+  <PropertyGroup>
+    <PreBuildEvent>if $(ConfigurationName) == Release  (
+    npm install &amp; npm run build
+    ) else (
+    npm install &amp; npm run build:dev
+    )</PreBuildEvent>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Linq.Expressions">
       <HintPath>..\packages\Mono.Linq.Expressions.1.1.0.0\lib\Mono.Linq.Expressions.dll</HintPath>


### PR DESCRIPTION
I had a problem with Extension which was adding extra empty lines to my .csproj within a section of PreBuild. 

I do believe there was a problem with matching the line ending which caused the problem. This change prevents from adding this extra empty lines. 