### PR TITLE
Item types now get grouped into unique item groups.

### DIFF
--- a/src/csproj.ts
+++ b/src/csproj.ts
@@ -2,12 +2,12 @@ import * as vscode from 'vscode'
 import * as fs from 'mz/fs'
 import * as path from 'path'
 
-import {Csproj, XML} from './types'
+import { Csproj, XML } from './types'
 
 const etree = require('@azz/elementtree')
 const stripBom = require('strip-bom')
 
-export class NoCsprojError extends Error {}
+export class NoCsprojError extends Error { }
 
 let _cacheXml: { [path: string]: XML } = Object.create(null)
 
@@ -41,7 +41,7 @@ export function relativeTo(csproj: Csproj, filePath: string) {
 }
 
 export function addFile(csproj: Csproj, filePath: string, itemType: string) {
-    const itemGroups = csproj.xml.getroot().findall('./ItemGroup')
+    const itemGroups = csproj.xml.getroot().findall(`./ItemGroup/${itemType}/..`)
     const itemGroup = itemGroups.length
         ? itemGroups[itemGroups.length - 1]
         : etree.SubElement(csproj.xml.getroot(), 'ItemGroup')


### PR DESCRIPTION
The extension now doesn't just put new items into the last item group.

Instead it uses the last item group that already has an item of the same type.